### PR TITLE
Use sample_weight in the metric calculations in model validations

### DIFF
--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -488,7 +488,6 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     # Adjust length of sample weights
     fit_params = fit_params if fit_params is not None else {}
 
-    # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
     # Appears before fit_params indexing because the update to fit_params
     # is reassigned to fit_params and throws away test-based sample weights.
     if 'sample_weight' in fit_params and \
@@ -499,7 +498,6 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
             test)
     else:
         test_sample_weight = None
-    # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
 
     fit_params = {k: _index_param_value(X, v, train)
                   for k, v in fit_params.items()}
@@ -559,19 +557,12 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     else:
         fit_time = time.time() - start_time
         # _score will return dict if is_multimetric is True
-        # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
         test_scores = _score(estimator, X_test, y_test, scorer, is_multimetric, test_sample_weight)
-        # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-        # test_scores = _score(estimator, X_test, y_test, scorer, is_multimetric)
 
         score_time = time.time() - start_time - fit_time
         if return_train_score:
-            # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
             train_scores = _score(estimator, X_train, y_train, scorer,
                                   is_multimetric, fit_params.get('sample_weight', None))
-            # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-            # train_scores = _score(estimator, X_train, y_train, scorer,
-            #                       is_multimetric)
     if verbose > 2:
         if is_multimetric:
             for scorer_name in sorted(test_scores):
@@ -604,35 +595,16 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     return ret
 
 
-# vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
 def _score(estimator, X_test, y_test, scorer, is_multimetric=False, sample_weight=None):
-# ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-# def _score(estimator, X_test, y_test, scorer, is_multimetric=False):
     """Compute the score(s) of an estimator on a given test set.
 
     Will return a single float if is_multimetric is False and a dict of floats,
     if is_multimetric is True
     """
     if is_multimetric:
-        # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
         return _multimetric_score(estimator, X_test, y_test, scorer, sample_weight)
-        # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-        # return _multimetric_score(estimator, X_test, y_test, scorer)
     else:
-        # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
         score = _apply_scorer(estimator, X_test, y_test, scorer, sample_weight)
-        # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-
-        # if y_test is None:
-        #     # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
-        #     score = scorer(estimator, X_test, sample_weight=sample_weight)
-        #     # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-        #     # score = scorer(estimator, X_test)
-        # else:
-        #     # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
-        #     score = scorer(estimator, X_test, y_test, sample_weight=sample_weight)
-        #     # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-        #     # score = scorer(estimator, X_test, y_test)
 
         if hasattr(score, 'item'):
             try:
@@ -649,28 +621,12 @@ def _score(estimator, X_test, y_test, scorer, is_multimetric=False, sample_weigh
     return score
 
 
-# vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
 def _multimetric_score(estimator, X_test, y_test, scorers, sample_weight):
-# ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-# def _multimetric_score(estimator, X_test, y_test, scorers):
     """Return a dict of score for multimetric scoring"""
     scores = {}
 
     for name, scorer in scorers.items():
-        # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
         score = _apply_scorer(estimator, X_test, y_test, scorer, sample_weight)
-        # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-
-        # if y_test is None:
-        #     # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
-        #     score = scorer(estimator, X_test, sample_weight=sample_weight)
-        #     # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-        #     # score = scorer(estimator, X_test)
-        # else:
-        #     # vvvvvvvvvvvvvvvvvvvv   RMD   vvvvvvvvvvvvvvvvvvvv
-        #     score = scorer(estimator, X_test, y_test, sample_weight=sample_weight)
-        #     # ^^^^^^^^^^^^^^^^^^^^   RMD   ^^^^^^^^^^^^^^^^^^^^
-        #     # score = scorer(estimator, X_test, y_test)
 
         if hasattr(score, 'item'):
             try:

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -715,6 +715,8 @@ def _apply_scorer(estimator, X, y, scorer, sample_weight):
                         "but supplied a scorer that doesn't accept a " 
                         "'sample_weight' parameter."
                     ), e)
+            else:
+                raise e
     return score
 
 

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -391,6 +391,10 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
                    error_score='raise-deprecating'):
     """Fit estimator and compute scores for a given dataset split.
 
+    NOTE: If sample_weight is supplied in ``fit_params``, it will be used for
+          both learning and will be passed to scorer for use in metric
+          calculations.
+
     Parameters
     ----------
     estimator : estimator object implementing 'fit'

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -557,12 +557,14 @@ def _fit_and_score(estimator, X, y, scorer, train, test, verbose,
     else:
         fit_time = time.time() - start_time
         # _score will return dict if is_multimetric is True
-        test_scores = _score(estimator, X_test, y_test, scorer, is_multimetric, test_sample_weight)
+        test_scores = _score(estimator, X_test, y_test, scorer,
+                             is_multimetric, test_sample_weight)
 
         score_time = time.time() - start_time - fit_time
         if return_train_score:
             train_scores = _score(estimator, X_train, y_train, scorer,
-                                  is_multimetric, fit_params.get('sample_weight', None))
+                                  is_multimetric,
+                                  fit_params.get('sample_weight', None))
     if verbose > 2:
         if is_multimetric:
             for scorer_name in sorted(test_scores):
@@ -601,6 +603,10 @@ def _score(estimator, X_test, y_test, scorer, is_multimetric=False, sample_weigh
     Will return a single float if is_multimetric is False and a dict of floats,
     if is_multimetric is True
     """
+
+    # sample_weight is optional because we want to put it at the end to allow
+    # backward compatibility.
+
     if is_multimetric:
         return _multimetric_score(estimator, X_test, y_test, scorer, sample_weight)
     else:

--- a/sklearn/model_selection/_validation.py
+++ b/sklearn/model_selection/_validation.py
@@ -698,6 +698,11 @@ def _apply_scorer(estimator, X, y, scorer, sample_weight):
             score = scorer(estimator, X, y)
     else:
         try:
+            # Explicitly force the sample_weight parameter so that an error
+            # will be raised in the event that the scorer doesn't take a
+            # sample_weight argument.  This is preferable to passing it as
+            # a keyword args dict in the case that it just ignores parameters
+            # that are not accepted by the scorer.
             if y is None:
                 score = scorer(estimator, X, sample_weight=sample_weight)
             else:

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1632,9 +1632,6 @@ def test_sample_weight():
         error_score='raise-deprecating'
     )
 
-    # It is appropriate to use exact tests and not np.isclose because
-    # accuracy should be computed exactly since it's based on
-    # counts.
     train_metric = res[0][metric_name]
     test_metric = res[1][metric_name]
 
@@ -1644,5 +1641,9 @@ def test_sample_weight():
     assert test_metric != np.sum(y[test]) / y[test].shape[0]
 
     # The proper sampled weighted metric value.
+    #
+    # It is appropriate to use exact tests and not np.isclose because
+    # accuracy should be computed exactly since it's based on
+    # counts.
     assert train_metric == exp_train_pr
     assert test_metric == exp_test_acc

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1582,3 +1582,66 @@ def test_score():
     fit_and_score_args = [None, None, None, two_params_scorer]
     assert_raise_message(ValueError, error_message,
                          _score, *fit_and_score_args)
+
+
+def test_sample_weight():
+    X = np.ones([4, 1])         # Constant features to learn intercept.
+    y = np.array([1, 0, 1, 0])  # Some +/- for both test and train.
+    train = np.array([0, 1])    # First two indices are train.
+    test = np.array([2, 3])     # Last two indices are test.
+    sample_weight = np.array([2000000, 1000000, 1, 1000000])
+
+    exp_test_acc = np.dot(y[test], sample_weight[test]) / np.sum(
+        sample_weight[test])
+    exp_train_pr = np.dot(y[train], sample_weight[train]) / np.sum(
+        sample_weight[train])
+    exp_preds = np.array([exp_train_pr] * test.shape[0])
+
+    random_state = 15432
+    estimator = LogisticRegression()
+
+    # Step 1: Check that the classifier learned the sample weighted class
+    #         prior probability.  Check predict_proba versus the known
+    #         class prior: exp_train_pr.
+    est_clone = clone(estimator)
+    est_clone.set_params(random_state=random_state)
+    est_clone.fit(X[tuple(train), :], y[train], sample_weight[train])
+    preds = est_clone.predict_proba(X[tuple(test), :])[:, 1]
+    np.testing.assert_array_almost_equal(exp_preds, preds)
+
+    # Step 2: Check that the accuracy computation in _fit_and_score
+    #         respects sample_weight.
+
+    metric_name = 'accuracy'
+    scorer = {metric_name: make_scorer(accuracy_score)}
+
+    res = _fit_and_score(
+        estimator, X, y, scorer, train, test,
+        verbose=0,
+        parameters=dict(random_state=random_state),
+        fit_params=dict(sample_weight=sample_weight),
+
+        # Based on parameters from in _fit_and_score when called from
+        # RandomizedSearchCV.fit
+        return_train_score='warn',
+        return_parameters=False,
+        return_n_test_samples=True,
+        return_times=True,
+        return_estimator=False,
+        error_score='raise-deprecating'
+    )
+
+    # It is appropriate to use exact tests and not np.isclose because
+    # accuracy should be computed exactly since it's based on
+    # counts.
+    train_metric = res[0][metric_name]
+    test_metric = res[1][metric_name]
+
+    # Unnecessary extra test to illustrate that this is not the desired
+    # metric value (but previously what has been historically returned).
+    assert train_metric != np.sum(y[train]) / y[train].shape[0]
+    assert test_metric != np.sum(y[test]) / y[test].shape[0]
+
+    # The proper sampled weighted metric value.
+    assert train_metric == exp_train_pr
+    assert test_metric == exp_test_acc

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1603,6 +1603,7 @@ def test_sample_weight():
     # Step 1: Check that the classifier learned the sample weighted class
     #         prior probability.  Check predict_proba versus the known
     #         class prior: exp_train_pr.
+    #
     est_clone = clone(estimator)
     est_clone.set_params(random_state=random_state)
     est_clone.fit(X[tuple(train), :], y[train], sample_weight[train])
@@ -1611,7 +1612,7 @@ def test_sample_weight():
 
     # Step 2: Check that the accuracy computation in _fit_and_score
     #         respects sample_weight.
-
+    #
     metric_name = 'accuracy'
     scorer = {metric_name: make_scorer(accuracy_score)}
 


### PR DESCRIPTION
# Purpose

To correct metric calculations in model validation (and cross validation) by attempting to use `sample_weight` in the metric calculations when `sample_weight` are supplied in `fit_params`.


#### Reference Issues/PRs

Fixes #4632.  See also #10806.


#### What does this implement/fix? Explain your changes.

This change always uses the same `sample_weight` used in training to weight the metric calculations in `_fit_and_score` and functions called by `_fit_and_score`, so it should be thought of changing the default behavior of things like cross validation.  This is unlike PR #10806 in that it is isolated to `_validation.py` and doesn't touch `_search.py`.  This is very intentional.


#### Any other comments?

This PR provides a simple test showing how unweighted metrics have very unfavorable consequences when models are trained with importance weights but not scored with the same weights.  It is shown in the test that the current omission of `sample_weight` in metrics calculations considerably overestimates the accuracy (0.5 accuracy vs  9.99999 * 10^-7).
