### PR TITLE
Use sample_weight in the metric calculations in model validations and cross validation

### DIFF
--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -886,8 +886,6 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
                    splits=True, rank=True,
                    weights=test_sample_counts if iid else None)
             if self.return_train_score:
-                # _store('train_%s' % scorer_name, train_scores[scorer_name],
-                #        splits=True)
                 _store('train_%s' % scorer_name, train_scores[scorer_name],
                        splits=True,
                        weights=train_sample_counts if iid else None)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -840,7 +840,7 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
         if self.return_train_score:
             if train_sample_weight_sums is None:
                 # Because the cv iterators may not iterate over the entire
-                # dataset we can't just use the dataset size directly.
+                # dataset, we can't just use the dataset size directly.
                 samples = int(np.sum(test_sample_counts[:n_splits]))
                 train_sample_counts = samples - \
                     np.array(test_sample_counts[:n_splits], dtype=np.int)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -839,6 +839,8 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
         # test_sample_weight_sums.
         if self.return_train_score:
             if train_sample_weight_sums is None:
+                # Because the cv iterators may not iterate over the entire
+                # dataset we can't just use the dataset size directly.
                 samples = int(np.sum(test_sample_counts[:n_splits]))
                 train_sample_counts = samples - \
                     np.array(test_sample_counts[:n_splits], dtype=np.int)

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -840,9 +840,8 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
         if self.return_train_score:
             if train_sample_weight_sums is None:
                 samples = int(np.sum(test_sample_counts[:n_splits]))
-                train_sample_counts = \
-                    np.array(test_sample_counts[:n_splits], dtype=np.int) - \
-                    samples
+                train_sample_counts = samples - \
+                    np.array(test_sample_counts[:n_splits], dtype=np.int)
             else:
                 train_sample_counts = np.array(
                     train_sample_weight_sums[:n_splits],

--- a/sklearn/model_selection/_search.py
+++ b/sklearn/model_selection/_search.py
@@ -651,7 +651,7 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
             def is_none(x):
                 return x is None
 
-            def collape_nones(xs):
+            def collapse_nones(xs):
                 return None if xs is None or any(map(is_none, xs)) else xs
 
             def weights_sums(train_ind, test_ind, sample_weight):
@@ -702,8 +702,8 @@ class BaseSearchCV(BaseEstimator, MetaEstimatorMixin, metaclass=ABCMeta):
                 else:
                     out, train_wts, test_wts = ([], [], [])
 
-                train_wts = collape_nones(train_wts)
-                test_wts = collape_nones(test_wts)
+                train_wts = collapse_nones(train_wts)
+                test_wts = collapse_nones(test_wts)
 
                 if len(out) < 1:
                     raise ValueError('No fits were performed. '

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1654,20 +1654,19 @@ def test_sample_weight():
     assert test_metric == exp_test_acc
 
 
-@pytest.mark.parametrize(
-    "met_name,metric,greater_is_better,needs_proba,sample_wt", [
-    ("accuracy", accuracy_score, True, False, [1, 999999, 1, 999999]),
-    ("accuracy", accuracy_score, True, False, [100000, 200000, 100000, 200000]),
-    ("accuracy", accuracy_score, True, False, [100000, 100000, 100000, 100000]),
-    ("accuracy", accuracy_score, True, False, [200000, 100000, 200000, 100000]),
-    ("accuracy", accuracy_score, True, False, [999999, 1, 999999, 1]),
-    ("accuracy", accuracy_score, True, False, [2000000, 1000000, 1, 999999]),
-    ("precision", precision_score, True, False, [2000000, 1000000, 1, 999999]),
-    ("neg_log_loss", log_loss, False, True, [2500000, 500000, 200000, 100000]),
-    ("brier_score_loss", brier_score_loss, False, True, [2500000, 500000, 200000, 100000]),
+@pytest.mark.parametrize("metric,greater_is_better,needs_proba,sample_wt", [
+    (accuracy_score, True, False, [1, 999999, 1, 999999]),
+    (accuracy_score, True, False, [100000, 200000, 100000, 200000]),
+    (accuracy_score, True, False, [100000, 100000, 100000, 100000]),
+    (accuracy_score, True, False, [200000, 100000, 200000, 100000]),
+    (accuracy_score, True, False, [999999, 1, 999999, 1]),
+    (accuracy_score, True, False, [2000000, 1000000, 1, 999999]),
+    (precision_score, True, False, [2000000, 1000000, 1, 999999]),
+    (log_loss, False, True, [2500000, 500000, 200000, 100000]),
+    (brier_score_loss, False, True, [2500000, 500000, 200000, 100000]),
 ])
 def test_sample_weight_cross_validation(
-        met_name, metric, greater_is_better, needs_proba, sample_wt):
+        metric, greater_is_better, needs_proba, sample_wt):
     # Test that cross validation properly uses sample_weight from fit_params
     # when calculating the desired metrics.
 
@@ -1704,7 +1703,7 @@ def test_sample_weight_cross_validation(
     gscv = GridSearchCV(
         LogisticRegression(),
         param_grid={"random_state": [15432]},
-        scoring=met_name,
+        scoring=make_scorer(metric, greater_is_better, needs_proba),
         cv=2,
         return_train_score=True
     )

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1671,12 +1671,21 @@ def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2, exp):
     sample_weight = np.array(sample_wt)
 
     sum_sample_weight = np.sum(sample_weight)
+
     norm1_wt_f1 = sample_weight[f1] / np.sum(sample_weight[f1])
+    y1 = y[f1]
+    model2 = [np.round(np.dot(y[f2], sample_weight[f2])/np.sum(sample_weight[f2]))] * len(f2)
+    sklearn_acc1 = accuracy_score(y1, model2, sample_weight=sample_weight[f1])
+
     acc1 = np.dot(y[f1], norm1_wt_f1)
     acc1 = acc1 if not flip_acc_1 else 1 - acc1
     ratio_wt_f1 = np.sum(sample_weight[f1]) / sum_sample_weight
 
     norm1_wt_f2 = sample_weight[f2] / np.sum(sample_weight[f2])
+    y2 = y[f2]
+    model1 = [np.round(np.dot(y[f1], sample_weight[f1])/np.sum(sample_weight[f1]))] * len(f1)
+    sklearn_acc2 = accuracy_score(y2, model1, sample_weight=sample_weight[f2])
+
     acc2 = np.dot(y[f2], norm1_wt_f2)
     acc2 = acc2 if not flip_acc_2 else 1 - acc2
     ratio_wt_f2 = np.sum(sample_weight[f2]) / sum_sample_weight
@@ -1697,6 +1706,8 @@ def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2, exp):
 
     # Assert the above math for exp_cv_acc is correct.
     np.testing.assert_almost_equal(exp_cv_acc, exp, decimal=12)
+    np.testing.assert_almost_equal(acc1, sklearn_acc1, decimal=12)
+    np.testing.assert_almost_equal(acc2, sklearn_acc2, decimal=12)
 
     # Assert that the sample weights for each fold were normalized by the
     # L1 norm.

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1652,13 +1652,13 @@ def test_sample_weight():
     assert test_metric == exp_test_acc
 
 
-@pytest.mark.parametrize("sample_wt,flip_acc_1,flip_acc_2, exp", [
-    ([1, 999999, 1, 999999], False, False, 999999/1000000),
-    ([100000, 200000, 100000, 200000], False, False, 2/3),
-    ([100000, 100000, 100000, 100000], False, False, 1/2),
-    ([200000, 100000, 200000, 100000], True, True, 2/3),
-    ([999999, 1, 999999, 1], True, True, 999999/1000000),
-    ([2000000, 1000000, 1, 999999], False, True, 1000001/4000000)
+@pytest.mark.parametrize("sample_wt,flip_acc_1,flip_acc_2,exp", [
+    ([1, 999999, 1, 999999], True, True, 999999/1000000),
+    ([100000, 200000, 100000, 200000], True, True, 2/3),
+    ([100000, 100000, 100000, 100000], True, True, 1/2),
+    ([200000, 100000, 200000, 100000], False, False, 2/3),
+    ([999999, 1, 999999, 1], False, False, 999999/1000000),
+    ([2000000, 1000000, 1, 999999], True, False, 1000001/4000000)
 ])
 def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2, exp):
     # Test that cross validation properly uses sample_weight from fit_params
@@ -1673,12 +1673,12 @@ def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2, exp):
     sum_sample_weight = np.sum(sample_weight)
     norm1_wt_f1 = sample_weight[f1] / np.sum(sample_weight[f1])
     acc1 = np.dot(y[f1], norm1_wt_f1)
-    acc1 = acc1 if flip_acc_1 else 1 - acc1
+    acc1 = acc1 if not flip_acc_1 else 1 - acc1
     ratio_wt_f1 = np.sum(sample_weight[f1]) / sum_sample_weight
 
     norm1_wt_f2 = sample_weight[f2] / np.sum(sample_weight[f2])
     acc2 = np.dot(y[f2], norm1_wt_f2)
-    acc2 = acc2 if flip_acc_2 else 1 - acc2
+    acc2 = acc2 if not flip_acc_2 else 1 - acc2
     ratio_wt_f2 = np.sum(sample_weight[f2]) / sum_sample_weight
 
     exp_cv_acc = acc1 * ratio_wt_f1 + acc2 * ratio_wt_f2

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1653,7 +1653,11 @@ def test_sample_weight():
 
 
 @pytest.mark.parametrize("sample_wt,flip_acc_1,flip_acc_2", [
+    ([1, 999999, 1, 999999], False, False),
     ([100000, 200000, 100000, 200000], False, False),
+    ([100000, 100000, 100000, 100000], False, False),
+    ([200000, 100000, 200000, 100000], True, True),
+    ([999999, 1, 999999, 1], True, True),
     ([2000000, 1000000, 1, 999999], False, True)
 ])
 def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2):

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1662,13 +1662,14 @@ def test_sample_weight_cross_validation():
     f2 = np.array([2, 3])       # Fold 2.
     sample_weight = np.array([2000000, 1000000, 1, 999999])
 
+    sum_sample_weight = np.sum(sample_weight)
     norm1_wt_f1 = sample_weight[f1] / np.sum(sample_weight[f1])
     acc1 = (1 - np.dot(y[f1], norm1_wt_f1))
-    ratio_wt_f1 = np.sum(sample_weight[f1]) / np.sum(sample_weight)
+    ratio_wt_f1 = np.sum(sample_weight[f1]) / sum_sample_weight
 
     norm1_wt_f2 = sample_weight[f2] / np.sum(sample_weight[f2])
     acc2 = np.dot(y[f2], norm1_wt_f2)
-    ratio_wt_f2 = np.sum(sample_weight[f2]) / np.sum(sample_weight)
+    ratio_wt_f2 = np.sum(sample_weight[f2]) / sum_sample_weight
 
     # 0.25000025 = 1000001 / 4000000 = 1/3 * 3/4 + 1/1000000 * 1/4
     exp_cv_acc = acc1 * ratio_wt_f1 + acc2 * ratio_wt_f2
@@ -1684,6 +1685,13 @@ def test_sample_weight_cross_validation():
     gscv.fit(X, y, sample_weight=sample_weight)
     best_score = gscv.best_score_
     np.testing.assert_almost_equal(best_score, exp_cv_acc)
+
+    # Assert that the sample weights for each fold were normalized by the
+    # L1 norm.
+    np.testing.assert_almost_equal(np.sum(norm1_wt_f1), 1)
+    np.all(norm1_wt_f1 >= 0)
+    np.testing.assert_almost_equal(np.sum(norm1_wt_f2), 1)
+    np.all(norm1_wt_f2 >= 0)
 
 
 @pytest.mark.parametrize("replications,sample_wt,pass_none", [

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1700,9 +1700,10 @@ def test_sample_weight_cross_validation(
     sign = 1 if greater_is_better else -1
     exp_cv_score = sign * (met1 * ratio_wt_f1 + met2 * ratio_wt_f2)
 
+    # There's nothing special about GridSearchCV. Could be RandomizedSearchCV.
     gscv = GridSearchCV(
         LogisticRegression(),
-        param_grid={"random_state": [15432]},
+        {"random_state": [15432]},  # parameters
         scoring=make_scorer(metric, greater_is_better, needs_proba),
         cv=2,
         return_train_score=True

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1653,12 +1653,12 @@ def test_sample_weight():
 
 
 @pytest.mark.parametrize("sample_wt,flip_acc_1,flip_acc_2, exp", [
-    ([1, 999999, 1, 999999], False, False, 0.999999),
-    ([100000, 200000, 100000, 200000], False, False, 2/3.0),
-    ([100000, 100000, 100000, 100000], False, False, 1/2.0),
-    ([200000, 100000, 200000, 100000], True, True, 2/3.0),
-    ([999999, 1, 999999, 1], True, True, 0.999999),
-    ([2000000, 1000000, 1, 999999], False, True, 0.25000025)
+    ([1, 999999, 1, 999999], False, False, 999999/1000000),
+    ([100000, 200000, 100000, 200000], False, False, 2/3),
+    ([100000, 100000, 100000, 100000], False, False, 1/2),
+    ([200000, 100000, 200000, 100000], True, True, 2/3),
+    ([999999, 1, 999999, 1], True, True, 999999/1000000),
+    ([2000000, 1000000, 1, 999999], False, True, 1000001/4000000)
 ])
 def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2, exp):
     # Test that cross validation properly uses sample_weight from fit_params

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -1652,15 +1652,15 @@ def test_sample_weight():
     assert test_metric == exp_test_acc
 
 
-@pytest.mark.parametrize("sample_wt,flip_acc_1,flip_acc_2", [
-    ([1, 999999, 1, 999999], False, False),
-    ([100000, 200000, 100000, 200000], False, False),
-    ([100000, 100000, 100000, 100000], False, False),
-    ([200000, 100000, 200000, 100000], True, True),
-    ([999999, 1, 999999, 1], True, True),
-    ([2000000, 1000000, 1, 999999], False, True)
+@pytest.mark.parametrize("sample_wt,flip_acc_1,flip_acc_2, exp", [
+    ([1, 999999, 1, 999999], False, False, 0.999999),
+    ([100000, 200000, 100000, 200000], False, False, 2/3.0),
+    ([100000, 100000, 100000, 100000], False, False, 1/2.0),
+    ([200000, 100000, 200000, 100000], True, True, 2/3.0),
+    ([999999, 1, 999999, 1], True, True, 0.999999),
+    ([2000000, 1000000, 1, 999999], False, True, 0.25000025)
 ])
-def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2):
+def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2, exp):
     # Test that cross validation properly uses sample_weight from fit_params
     # when calculating the desired metrics.
 
@@ -1693,7 +1693,10 @@ def test_sample_weight_cross_validation(sample_wt, flip_acc_1, flip_acc_2):
 
     gscv.fit(X, y, sample_weight=sample_weight)
     best_score = gscv.best_score_
-    np.testing.assert_almost_equal(best_score, exp_cv_acc, decimal=12)
+    np.testing.assert_almost_equal(exp_cv_acc, best_score, decimal=12)
+
+    # Assert the above math for exp_cv_acc is correct.
+    np.testing.assert_almost_equal(exp_cv_acc, exp, decimal=12)
 
     # Assert that the sample weights for each fold were normalized by the
     # L1 norm.


### PR DESCRIPTION
# *DO NOT MERGE WITH PR WITHOUT ASKING!*

# Purpose

To correct metric calculations in model validation (and cross validation) by attempting to use `sample_weight` in the metric calculations when `sample_weight` are supplied in `fit_params`.

Adds sample weighting for model validation methods like cross validation inside `sklearn/model_selection/_validation.py` and `sklearn/model_selection/_search.py`.


#### Reference Issues/PRs

Fixes #4632.  See also #10806.


#### What does this implement/fix? Explain your changes.

This change always uses the same `sample_weight` used in training to weight the metric calculations in `_fit_and_score` and functions called by `_fit_and_score`, so it should be thought of changing the default behavior of things like cross validation.  This is similar to PR #10806 but doesn't allow separate test weights to be specified.  It changes `_validation.py` and `_search.py`.

None of the CV search classes (`GridSearchCV`, etc) are changed.  This operates at the function level.


#### Any other comments?

This PR provides some simple test showing how unweighted metrics have very unfavorable consequences when models are trained with importance weights but not scored with the same weights.  It is shown in the test that the current omission of `sample_weight` in metrics calculations considerably overestimates the accuracy.
